### PR TITLE
Fix 基于前端模版开发时可配置调用api地址 

### DIFF
--- a/app/api/utils/common.ts
+++ b/app/api/utils/common.ts
@@ -18,4 +18,4 @@ export const setSession = (sessionId: string) => {
   return { 'Set-Cookie': `session_id=${sessionId}` }
 }
 
-export const client = new CompletionClient(API_KEY, API_URL)
+export const client = new CompletionClient(API_KEY, API_URL ? API_URL : undefined)

--- a/app/api/utils/common.ts
+++ b/app/api/utils/common.ts
@@ -1,5 +1,5 @@
 import { type NextRequest } from 'next/server'
-import { APP_ID, API_KEY } from '@/config'
+import { APP_ID, API_KEY, API_URL } from '@/config'
 import { CompletionClient } from 'dify-client'
 import { v4 } from 'uuid'
 
@@ -18,4 +18,4 @@ export const setSession = (sessionId: string) => {
   return { 'Set-Cookie': `session_id=${sessionId}` }
 }
 
-export const client = new CompletionClient(API_KEY)
+export const client = new CompletionClient(API_KEY, API_URL)

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,7 +1,7 @@
 import { AppInfo } from "@/types/app"
 export const APP_ID = ''
 export const API_KEY = ''
-
+export const API_URL = ''
 export const APP_INFO: AppInfo = {
   "title": 'Text Generator APP',
   "description": 'App description',


### PR DESCRIPTION
解决部署本地或者部署远程服务器之后自定义域名无法验证API_KEY