### PR TITLE
Add support for file input type in prompt variables

### DIFF
--- a/utils/prompt.ts
+++ b/utils/prompt.ts
@@ -27,6 +27,9 @@ export const userInputsFormToPromptVariables = (useInputs: UserInputFormItem[] |
       if (item.number)
         return ['number', item.number]
 
+      if (item.file)
+        return ['file', item.file]
+
       return ['select', item.select]
     })()
     if (type === 'string' || type === 'paragraph') {


### PR DESCRIPTION
Add support for file input type in prompt variables.

When missing this type. will show 500 in the frontend.