### PR TITLE
feat(config): Add app base URL path and API prefix configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ NEXT_PUBLIC_API_URL=
 # APP type
 # true for workflow apps
 NEXT_PUBLIC_APP_TYPE_WORKFLOW=
+# Base URL path for the application
+NEXT_PUBLIC_APP_BASE_URL_PATH=
+# API prefix path for the application
+NEXT_PUBLIC_API_PREFIX=

--- a/config/index.ts
+++ b/config/index.ts
@@ -11,7 +11,7 @@ export const APP_INFO: AppInfo = {
   default_language: 'en-US',
 }
 
-export const API_PREFIX = '/api'
+export const API_PREFIX = `${process.env.NEXT_PUBLIC_API_PREFIX || '/api'}`
 
 export const LOCALE_COOKIE_NAME = 'locale'
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: process.env.NEXT_PUBLIC_APP_BASE_URL_PATH,
   productionBrowserSourceMaps: false, // enable browser source map generation during the production build
   // Configure pageExtensions to include md and mdx
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],


### PR DESCRIPTION
we must publish mult agents on the site, so we 分配 sub path for every agent, the PR can simplify this configeration. 