### PR TITLE
fix: correct i18n key for optional variables placeholder

### DIFF
--- a/app/components/config-scence/index.tsx
+++ b/app/components/config-scence/index.tsx
@@ -72,7 +72,7 @@ const ConfigSence: FC<IConfigSenceProps> = ({
                   <input
                     type="number"
                     className="block w-full p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500 "
-                    placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
+                    placeholder={`${item.name}${!item.required ? `(${t('app.common.optional')})` : ''}`}
                     value={inputs[item.key]}
                     onChange={(e) => { onInputsChange({ ...inputs, [item.key]: e.target.value }) }}
                   />

--- a/app/components/run-once/index.tsx
+++ b/app/components/run-once/index.tsx
@@ -59,7 +59,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                   <input
                     type="text"
                     className="block w-full p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500 "
-                    placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
+                    placeholder={`${item.name}${!item.required ? `(${t('app.common.optional')})` : ''}`}
                     value={inputs[item.key]}
                     onChange={(e) => { onInputsChange({ ...inputs, [item.key]: e.target.value }) }}
                     maxLength={item.max_length || DEFAULT_VALUE_MAX_LEN}
@@ -68,7 +68,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                 {item.type === 'paragraph' && (
                   <textarea
                     className="block w-full h-[104px] p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500 "
-                    placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
+                    placeholder={`${item.name}${!item.required ? `(${t('app.common.optional')})` : ''}`}
                     value={inputs[item.key]}
                     onChange={(e) => { onInputsChange({ ...inputs, [item.key]: e.target.value }) }}
                   />
@@ -77,7 +77,7 @@ const RunOnce: FC<IRunOnceProps> = ({
                   <input
                     type="number"
                     className="block w-full p-2 text-gray-900 border border-gray-300 rounded-lg bg-gray-50 sm:text-xs focus:ring-blue-500 focus:border-blue-500 "
-                    placeholder={`${item.name}${!item.required ? `(${t('appDebug.variableTable.optional')})` : ''}`}
+                    placeholder={`${item.name}${!item.required ? `(${t('app.common.optional')})` : ''}`}
                     value={inputs[item.key]}
                     onChange={(e) => { onInputsChange({ ...inputs, [item.key]: e.target.value }) }}
                   />


### PR DESCRIPTION
This PR fixes an issue where the placeholder for optional input variables was displaying the raw i18n key string (appDebug.variableTable.optional) instead of the actual translated text (e.g., "(Optional)" or "（可选）").

The issue was caused by using a translation key that does not exist in the webapp-text-generator locale files. I have updated the key to app.common.optional, which is correctly defined in i18n/lang/app.zh.ts and app.en.ts.